### PR TITLE
syntax highlighting to a dark theme

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -3,6 +3,8 @@
  */
 
 @import url('https://fonts.googleapis.com/css?family=Open+Sans');
+@import url('https://fonts.googleapis.com/css?family=Ubuntu+Mono');
+
 
 body, h1, h2, h3, h4, h5, h6,
 p, blockquote, pre, hr,
@@ -322,140 +324,207 @@ pre {
 /**
  * Syntax highlighting styles
  */
+
 .highlight {
-  background: #fff; }
-  .highlighter-rouge .highlight {
-    background: #efefef; }
-  .highlight .c {
-    color: #998;
-    font-style: italic; }
-  .highlight .err {
+    background: #fff;
+}
+.highlighter-rouge .highlight {
+    background: #292d3e;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.4);
+    border: 0;
+    padding: 15px 25px;
+}
+.highlight .c {
+    color: #676e95;
+    font-style: italic;
+}
+.highlight .err {
     color: #a61717;
-    background-color: #e3d2d2; }
-  .highlight .k {
-    font-weight: bold; }
-  .highlight .o {
-    font-weight: bold; }
-  .highlight .cm {
+    background-color: #e3d2d2;
+}
+.highlight .k {
+    color: #F48FB1;
+}
+.highlight .o {
+    color: #a2aace;
+}
+.highlight .cm {
     color: #998;
-    font-style: italic; }
-  .highlight .cp {
-    color: #999;
-    font-weight: bold; }
-  .highlight .c1 {
+    font-style: italic;
+}
+.highlight .cp {
+    color: #b8c1ef;
+    font-weight: bold;
+}
+.highlight .c1 {
     color: #998;
-    font-style: italic; }
-  .highlight .cs {
+    font-style: italic;
+}
+.highlight .cs {
     color: #999;
     font-weight: bold;
-    font-style: italic; }
-  .highlight .gd {
+    font-style: italic;
+}
+.highlight .gd {
     color: #000;
-    background-color: #fdd; }
-  .highlight .gd .x {
+    background-color: #fdd;
+}
+.highlight .gd .x {
     color: #000;
-    background-color: #faa; }
-  .highlight .ge {
-    font-style: italic; }
-  .highlight .gr {
-    color: #a00; }
-  .highlight .gh {
-    color: #999; }
-  .highlight .gi {
+    background-color: #faa;
+}
+.highlight .ge {
+    font-style: italic;
+}
+.highlight .gr {
+    color: #a00;
+}
+.highlight .gh {
+    color: #999;
+}
+.highlight .gi {
     color: #000;
-    background-color: #dfd; }
-  .highlight .gi .x {
+    background-color: #dfd;
+}
+.highlight .gi .x {
     color: #000;
-    background-color: #afa; }
-  .highlight .go {
-    color: #888; }
-  .highlight .gp {
-    color: #555; }
-  .highlight .gs {
-    font-weight: bold; }
-  .highlight .gu {
-    color: #aaa; }
-  .highlight .gt {
-    color: #a00; }
-  .highlight .kc {
-    font-weight: bold; }
-  .highlight .kd {
-    font-weight: bold; }
-  .highlight .kp {
-    font-weight: bold; }
-  .highlight .kr {
-    font-weight: bold; }
-  .highlight .kt {
+    background-color: #afa;
+}
+.highlight .go {
+    color: #888;
+}
+.highlight .gp {
+    color: #555;
+}
+.highlight .gs {
+    font-weight: bold;
+}
+.highlight .gu {
+    color: #aaa;
+}
+.highlight .gt {
+    color: #a00;
+}
+.highlight .kc {
+    font-weight: bold;
+}
+.highlight .kd {
+    color: #ba89dc;
+}
+.highlight .kp {
+    font-weight: bold;
+}
+.highlight .kr {
+    font-weight: bold;
+}
+.highlight .kt {
     color: #458;
-    font-weight: bold; }
-  .highlight .m {
-    color: #099; }
-  .highlight .s {
-    color: #d14; }
-  .highlight .na {
-    color: #008080; }
-  .highlight .nb {
-    color: #0086B3; }
-  .highlight .nc {
-    color: #458;
-    font-weight: bold; }
-  .highlight .no {
-    color: #008080; }
-  .highlight .ni {
-    color: #800080; }
-  .highlight .ne {
+    font-weight: bold;
+}
+.highlight .m {
+    color: #099;
+}
+.highlight .s {
+    color: #c3e88d;
+}
+.highlight .na {
+    color: #FF9800;
+}
+.highlight .nb {
+    color: #80CBC4;
+}
+.highlight .nc {
+    color: #FF9800;
+    font-weight: bold;
+}
+.highlight .no {
+    color: #008080;
+}
+.highlight .ni {
+    color: #800080;
+}
+.highlight .ne {
     color: #900;
-    font-weight: bold; }
-  .highlight .nf {
-    color: #900;
-    font-weight: bold; }
-  .highlight .nn {
-    color: #555; }
-  .highlight .nt {
-    color: #000080; }
-  .highlight .nv {
-    color: #008080; }
-  .highlight .ow {
-    font-weight: bold; }
-  .highlight .w {
-    color: #bbb; }
-  .highlight .mf {
-    color: #099; }
-  .highlight .mh {
-    color: #099; }
-  .highlight .mi {
-    color: #099; }
-  .highlight .mo {
-    color: #099; }
-  .highlight .sb {
-    color: #d14; }
-  .highlight .sc {
-    color: #d14; }
-  .highlight .sd {
-    color: #d14; }
-  .highlight .s2 {
-    color: #d14; }
-  .highlight .se {
-    color: #d14; }
-  .highlight .sh {
-    color: #d14; }
-  .highlight .si {
-    color: #d14; }
-  .highlight .sx {
-    color: #d14; }
-  .highlight .sr {
-    color: #009926; }
-  .highlight .s1 {
-    color: #d14; }
-  .highlight .ss {
-    color: #990073; }
-  .highlight .bp {
-    color: #999; }
-  .highlight .vc {
-    color: #008080; }
-  .highlight .vg {
-    color: #008080; }
-  .highlight .vi {
-    color: #008080; }
-  .highlight .il {
-    color: #099; }
+    font-weight: bold;
+}
+.highlight .nf {
+    color: #82aaff;
+}
+.highlight .nn {
+    color: #F8BBD0;
+}
+.highlight .nt {
+    color: #000080;
+}
+.highlight .nv {
+    color: #008080;
+}
+.highlight .ow {
+    font-weight: bold;
+}
+.highlight .w {
+    color: #bbb;
+}
+.highlight .mf {
+    color: #099;
+}
+.highlight .mh {
+    color: #099;
+}
+.highlight .mi {
+    color: #00BCD4;
+}
+.highlight .mo {
+    color: #099;
+}
+.highlight .sb {
+    color: #d14;
+}
+.highlight .sc {
+    color: #d14;
+}
+.highlight .sd {
+    color: #d14;
+}
+.highlight .s2 {
+    color: #d14;
+}
+.highlight .se {
+    color: #d14;
+}
+.highlight .sh {
+    color: #d14;
+}
+.highlight .si {
+    color: #FFEB3B;
+}
+.highlight .sx {
+    color: #d14;
+}
+.highlight .sr {
+    color: #009926;
+}
+.highlight .s1 {
+    color: #c2e78d;
+}
+.highlight .p {
+    color: #a2aace;
+}
+.highlight .ss {
+    color: #990073;
+}
+.highlight .bp {
+    color: #CDDC39;
+}
+.highlight .vc {
+    color: #008080;
+}
+.highlight .vg {
+    color: #008080;
+}
+.highlight .vi {
+    color: #008080;
+}
+.highlight .il {
+    color: #099;
+}


### PR DESCRIPTION
- updated code blocks' font family to `ubuntu mono`.
- updated theme to a darker one.

Here's a sample:

![https://puu.sh/vk1yB/c62f1e793b.png](https://puu.sh/vk1yB/c62f1e793b.png)